### PR TITLE
Fix `gulp watch` for custom directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,25 +17,23 @@ var config   = elixir.config;
  | Minify PNG, JPEG, GIF and SVG images
  |
  */
-elixir.extend('imagemin', function(src, output, options) {
+elixir.extend('imagemin', function(options) {
 
-    config.images = {
+    config.images = _.extend({
         folder: 'images',
-        outputFolder: 'images',
+        outputFolder: 'images'
+    }, config.images || {});
 
-        pluginOptions: {
-            progressive: true,
-            svgoPlugins: [{removeViewBox: false}],
-            use: [pngquant()]
-        }
-    };
-
-    options = _.extend(config.images.pluginOptions, options);
+    options = _.extend({
+        progressive: true,
+        svgoPlugins: [{removeViewBox: false}],
+        use: [pngquant()]
+    }, options);
 
     new elixir.Task('imagemin', function () {
         var paths = new elixir.GulpPaths()
-            .src(src || config.get('assets.images.folder'))
-            .output(output || config.get('public.images.outputFolder'));
+            .src(config.get('assets.images.folder'))
+            .output(config.get('public.images.outputFolder'));
 
         return gulp.src(paths.src.path)
             .pipe(changed(paths.output.path))

--- a/readme.md
+++ b/readme.md
@@ -22,23 +22,72 @@ elixir(function(mix) {
 });
 ```
 
-This will scan your `resources/assets/images` directory for all image files. Instead, if you only want to process a
-different directory, you may do:
+This will scan your `resources/assets/images` directory for all image files.
+
+### Changing the default image directories
+
+If you want to process a different image directory, you can update your Elixir config by either:
+
+#### Defining `elixir.config.images` in your *Gulpfile*
+
+You can define `elixir.config.images` in your `gulpfile.js` like so:
 
 ```javascript
-mix.imagemin("./resources/assets/img");
+var elixir = require('laravel-elixir');
+
+require('laravel-elixir-imagemin');
+
+elixir.config.images = {
+    folder: 'img',
+    outputFolder: 'img'
+};
+
+elixir(function(mix) {
+   mix.imagemin();
+});
 ```
 
-Finally, if you'd like to output to a different directory than the default public/images, then you may override this as well.
+#### Setting `config.images` in an `elixir.json` file
+
+You can create an [`elixir.json`](https://github.com/laravel/elixir/blob/dfd6655537eb3294a4c71e826cd0e8a6f6b2108b/index.js#L50-L67)
+file in your project root to modify Elixir's default settings.
+
+```json
+{
+    "images": {
+        "folder": "img",
+        "outputFolder": "img"
+    }
+}
+```
+
+#### Upgrading from the old syntax
+
+If you're upgrading from the old syntax, where you defined custom directories like so:
 
 ```javascript
 mix.imagemin("./resources/assets/img", "public/images/foo/bar/");
 ```
 
-#### Advanced example
+All you have to do is:
 
-In third argument you could pass imagemin options.
+- Remove the first two parameters, then
+- Follow the instructions for ["Changing the default image directories"](#changing-the-default-image-directories)
+
+**Note**: You don't define the full path anymore. Instead of `resources/assets/img` you simply use `img`, because
+laravel-elixir-imagemin will look inside your `assets` and `public` directories (or whatever else you may have
+configured).
+
+### Custom imagemin options
+
+You can override the default imagemin options by passing in an options object like so:
 
 ```javascript
-mix.imagemin("./resources/assets/img", "public/img", { optimizationLevel: 3, progressive: true, interlaced: true });
+mix.imagemin({
+    optimizationLevel: 3,
+    progressive: true,
+    interlaced: true
+});
 ```
+
+Available imagemin options are listed [here in the gulp-imagemin readme](https://github.com/sindresorhus/gulp-imagemin#imageminoptions).


### PR DESCRIPTION
`gulp watch` doesn’t work with custom image directories. This fixes that
by extending `config.images` instead of hard-coding it.